### PR TITLE
Fix FullScreenFogRendererFeature for Unity 6000.4 compatibility

### DIFF
--- a/Assets/UniversalRenderPipelineGlobalSettings.asset
+++ b/Assets/UniversalRenderPipelineGlobalSettings.asset
@@ -29,7 +29,6 @@ MonoBehaviour:
   m_StripUnusedVariants: 1
   m_StripScreenCoordOverrideVariants: 1
   supportRuntimeDebugDisplay: 0
-  m_EnableRenderGraph: 0
   m_Settings:
     m_SettingsList:
       m_List:
@@ -67,6 +66,7 @@ MonoBehaviour:
       - rid: 5968994856238055429
       - rid: 5968994856238055430
       - rid: 5968994856238055431
+      - rid: 3312097802974134325
     m_RuntimeSettings:
       m_List: []
   m_AssetVersion: 10
@@ -227,7 +227,6 @@ MonoBehaviour:
       type: {class: RenderGraphSettings, ns: UnityEngine.Rendering.Universal, asm: Unity.RenderPipelines.Universal.Runtime}
       data:
         m_Version: 0
-        m_EnableRenderCompatibilityMode: 0
     - rid: 2666629137426022410
       type: {class: UniversalRendererResources, ns: UnityEngine.Rendering.Universal,
         asm: Unity.RenderPipelines.Universal.Runtime}
@@ -351,6 +350,23 @@ MonoBehaviour:
         m_ExportShaderVariants: 1
         m_ShaderVariantLogLevel: 0
         m_StripRuntimeDebugShaders: 1
+    - rid: 3312097802974134325
+      type: {class: WorldRenderPipelineResources, ns: UnityEngine.PathTracing.Core,
+        asm: Unity.PathTracing.Runtime}
+      data:
+        _version: 3
+        _blitCubemap: {fileID: 7200000, guid: 5a992812cb320d146a66cc600200cce7, type: 3}
+        _blitGrayScaleCookie: {fileID: 7200000, guid: 557fa399e33bf7647bda5697c5c158df,
+          type: 3}
+        _setAlphaChannelShader: {fileID: 7200000, guid: 5efaea0e81c66334aa9d062d6573e6fd,
+          type: 3}
+        _environmentImportanceSamplingBuild: {fileID: 7200000, guid: 5bb2534d2411d344cbc54f880232640f,
+          type: 3}
+        _skyBoxMesh: {fileID: 4300000, guid: 0529e6c5f6dea8c4a8c2835ed7de57cb, type: 2}
+        _sixFaceSkyBoxMesh: {fileID: 4300000, guid: a80925ceebd011741b42509226cefc74,
+          type: 2}
+        _buildLightGridShader: {fileID: 7200000, guid: 16e47c1641bd0104e92b624601457bb0,
+          type: 3}
     - rid: 5968994856238055424
       type: {class: RayTracingRenderPipelineResources, ns: UnityEngine.Rendering.UnifiedRayTracing,
         asm: Unity.UnifiedRayTracing.Runtime}

--- a/Packages/Fog/Runtime/FullScreenFogRendererFeature.cs
+++ b/Packages/Fog/Runtime/FullScreenFogRendererFeature.cs
@@ -20,7 +20,9 @@ namespace Meryuhi.Rendering
         class FullScreenFogRenderPass : ScriptableRenderPass
         {
             private PassData _passData;
+#if !UNITY_6000_4_OR_NEWER
             private RTHandle _copiedColor;
+#endif
 
             private static readonly int BlitTextureShaderID = Shader.PropertyToID("_BlitTexture");
             private static readonly int BlitScaleBias = Shader.PropertyToID("_BlitScaleBias");
@@ -39,7 +41,9 @@ namespace Meryuhi.Rendering
                 .Select(mode => ($"_{nameof(FullScreenFog.noiseMode).ToUpper()}_{mode.ToString().ToUpper()}", mode)).ToArray();
             private static readonly int NoiseTexShaderID = Shader.PropertyToID("_NoiseTex");
             private static readonly int NoiseParamsShaderID = Shader.PropertyToID("_NoiseParams");
+#if !UNITY_6000_4_OR_NEWER
             private static readonly string CopiedColorRTName = $"_{FullScreenFog.Name}CopiedColor";
+#endif
             private static readonly string CopyColorPassName = $"{FullScreenFog.Name}CopyColorPass";
             private static readonly string MainPassName = $"{FullScreenFog.Name}MainPass";
 
@@ -53,6 +57,7 @@ namespace Meryuhi.Rendering
                 _passData = passData;
             }
 
+#if !UNITY_6000_4_OR_NEWER
             ///From <see cref="FullScreenPassRendererFeature.FullScreenRenderPass"/>
             [Obsolete]
             public override void OnCameraSetup(CommandBuffer cmd, ref RenderingData renderingData)
@@ -72,10 +77,13 @@ namespace Meryuhi.Rendering
                 desc.depthStencilFormat = GraphicsFormat.None;
                 RenderingUtils.ReAllocateHandleIfNeeded(ref _copiedColor, desc, name: CopiedColorRTName);
             }
+#endif
 
             public void Dispose()
             {
+#if !UNITY_6000_4_OR_NEWER
                 _copiedColor?.Release();
+#endif
             }
 
             private static void ExecuteCopyColorPass(RasterCommandBuffer cmd, RTHandle sourceTexture)
@@ -149,6 +157,7 @@ namespace Meryuhi.Rendering
                 cmd.DrawProcedural(Matrix4x4.identity, material, 0, MeshTopology.Triangles, 3, 1);
             }
 
+#if !UNITY_6000_4_OR_NEWER
             [Obsolete]
             public override void Execute(ScriptableRenderContext context, ref RenderingData renderingData)
             {
@@ -168,6 +177,7 @@ namespace Meryuhi.Rendering
                 cmd.Clear();
                 CommandBufferPool.Release(cmd);
             }
+#endif
 
             public override void RecordRenderGraph(RenderGraph renderGraph, ContextContainer frameData)
             {
@@ -337,7 +347,10 @@ namespace Meryuhi.Rendering
             //TODO: maybe we do not need color input
             _renderPass.ConfigureInput(ScriptableRenderPassInput.Color | ScriptableRenderPassInput.Depth);
 
+#if !UNITY_6000_4_OR_NEWER
+            // The Compatibility Mode path samples the active camera color, so it must force an intermediate target.
             _renderPass.requiresIntermediateTexture = true;
+#endif
 
             renderer.EnqueuePass(_renderPass);
         }

--- a/Packages/manifest.json
+++ b/Packages/manifest.json
@@ -1,7 +1,7 @@
 {
   "dependencies": {
-    "com.unity.ide.visualstudio": "2.0.26",
-    "com.unity.render-pipelines.universal": "17.3.0",
+    "com.unity.ide.visualstudio": "2.0.27",
+    "com.unity.render-pipelines.universal": "17.4.0",
     "com.unity.ugui": "2.0.0",
     "com.unity.modules.accessibility": "1.0.0",
     "com.unity.modules.adaptiveperformance": "1.0.0",

--- a/Packages/packages-lock.json
+++ b/Packages/packages-lock.json
@@ -1,7 +1,7 @@
 {
   "dependencies": {
     "com.unity.burst": {
-      "version": "1.8.28",
+      "version": "1.8.29",
       "depth": 2,
       "source": "registry",
       "dependencies": {
@@ -11,17 +11,16 @@
       "url": "https://packages.unity.com"
     },
     "com.unity.collections": {
-      "version": "2.6.2",
+      "version": "6.4.0",
       "depth": 2,
-      "source": "registry",
+      "source": "builtin",
       "dependencies": {
         "com.unity.burst": "1.8.23",
         "com.unity.mathematics": "1.3.2",
-        "com.unity.test-framework": "1.4.6",
         "com.unity.nuget.mono-cecil": "1.11.5",
+        "com.unity.test-framework": "1.4.6",
         "com.unity.test-framework.performance": "3.0.3"
-      },
-      "url": "https://packages.unity.com"
+      }
     },
     "com.unity.ext.nunit": {
       "version": "2.0.5",
@@ -30,7 +29,7 @@
       "dependencies": {}
     },
     "com.unity.ide.visualstudio": {
-      "version": "2.0.26",
+      "version": "2.0.27",
       "depth": 0,
       "source": "registry",
       "dependencies": {
@@ -53,7 +52,7 @@
       "url": "https://packages.unity.com"
     },
     "com.unity.render-pipelines.core": {
-      "version": "17.3.0",
+      "version": "17.4.0",
       "depth": 1,
       "source": "builtin",
       "dependencies": {
@@ -61,27 +60,26 @@
         "com.unity.mathematics": "1.3.2",
         "com.unity.ugui": "2.0.0",
         "com.unity.collections": "2.4.3",
-        "com.unity.modules.physics": "1.0.0",
         "com.unity.modules.terrain": "1.0.0",
         "com.unity.modules.jsonserialize": "1.0.0"
       }
     },
     "com.unity.render-pipelines.universal": {
-      "version": "17.3.0",
+      "version": "17.4.0",
       "depth": 0,
       "source": "builtin",
       "dependencies": {
-        "com.unity.render-pipelines.core": "17.3.0",
-        "com.unity.shadergraph": "17.3.0",
-        "com.unity.render-pipelines.universal-config": "17.0.3"
+        "com.unity.render-pipelines.core": "17.4.0",
+        "com.unity.shadergraph": "17.4.0",
+        "com.unity.render-pipelines.universal-config": "17.4.0"
       }
     },
     "com.unity.render-pipelines.universal-config": {
-      "version": "17.0.3",
+      "version": "17.4.0",
       "depth": 1,
       "source": "builtin",
       "dependencies": {
-        "com.unity.render-pipelines.core": "17.0.3"
+        "com.unity.render-pipelines.core": "17.4.0"
       }
     },
     "com.unity.searcher": {
@@ -92,11 +90,11 @@
       "url": "https://packages.unity.com"
     },
     "com.unity.shadergraph": {
-      "version": "17.3.0",
+      "version": "17.4.0",
       "depth": 1,
       "source": "builtin",
       "dependencies": {
-        "com.unity.render-pipelines.core": "17.3.0",
+        "com.unity.render-pipelines.core": "17.4.0",
         "com.unity.searcher": "4.9.3"
       }
     },
@@ -111,7 +109,7 @@
       }
     },
     "com.unity.test-framework.performance": {
-      "version": "3.2.0",
+      "version": "3.4.0",
       "depth": 3,
       "source": "registry",
       "dependencies": {

--- a/ProjectSettings/ProjectVersion.txt
+++ b/ProjectSettings/ProjectVersion.txt
@@ -1,2 +1,2 @@
-m_EditorVersion: 6000.3.10f1
-m_EditorVersionWithRevision: 6000.3.10f1 (e35f0c77bd8e)
+m_EditorVersion: 6000.4.3f1
+m_EditorVersionWithRevision: 6000.4.3f1 (39d1a88d4dd1)

--- a/README.md
+++ b/README.md
@@ -6,7 +6,14 @@ This project will provide some URP-based fog effects, and implement it in a rela
 
 - URP v17
 
-  For URP v14~16, check urp14 branch
+### Unity 6 Compatibility Note
+
+Unity 6000.4 removed the URP `Compatibility Mode` option. This package keeps the old non-RenderGraph path only for Unity versions below `6000.4`, and uses the RenderGraph path on `6000.4+`.
+
+- Unity `6000.0` to `6000.3`: RenderGraph and `Compatibility Mode` are both supported.
+- Unity `6000.4+`: only the RenderGraph path is used.
+
+For URP v14~16, check urp14 branch
 
 ## Installation
 


### PR DESCRIPTION
Update project version to 6000.4.3f1 and enhance README with notes on Unity 6 compatibility. Adjust FullScreenFogRendererFeature to ensure compatibility with Unity 6000.4 by removing deprecated methods and implementing conditional compilation for older versions.

Fixes #7